### PR TITLE
流程语言拓展T4-Hiplot

### DIFF
--- a/build/apiserver/Dockerfile
+++ b/build/apiserver/Dockerfile
@@ -13,11 +13,13 @@ RUN apt update \
      && apt install -y --no-install-recommends ca-certificates openjdk-11-jre-headless \
      && apt clean \
      && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y cwltool
 ARG TARGETOS
 ARG TARGETARCH
-USER    nobody
+USER    root
 WORKDIR /app
-COPY --from=builder --chown=nobody:nogroup /go/src/github.com/Bio-OS/bioos/conf conf
+COPY --from=builder --chown=root:root /go/src/github.com/Bio-OS/bioos/conf conf
 COPY --from=builder /go/src/github.com/Bio-OS/bioos/_output/platforms/${TARGETOS}/${TARGETARCH}/apiserver .
 COPY --from=builder /go/src/github.com/Bio-OS/bioos/womtool.jar .
 ENTRYPOINT ["/app/apiserver"]

--- a/internal/context/submission/application/command/submission/command.go
+++ b/internal/context/submission/application/command/submission/command.go
@@ -15,7 +15,7 @@ type CreateSubmissionCommand struct {
 	Description    *string `validate:"omitempty,submissionDesc"`
 	Type           string  `validate:"required,oneof=dataModel filePath"`
 	Entity         *Entity
-	ExposedOptions ExposedOptions
+	ExposedOptions string
 	InOutMaterial  *InOutMaterial
 }
 
@@ -29,10 +29,6 @@ type Entity struct {
 type InOutMaterial struct {
 	InputsMaterial  string
 	OutputsMaterial string
-}
-
-type ExposedOptions struct {
-	ReadFromCache bool
 }
 
 type DeleteSubmissionCommand struct {

--- a/internal/context/submission/application/command/submission/create.go
+++ b/internal/context/submission/application/command/submission/create.go
@@ -45,16 +45,14 @@ func (c *createSubmissionHandler) Handle(ctx context.Context, cmd *CreateSubmiss
 	}
 
 	param := submission.CreateSubmissionParam{
-		Name:        cmd.Name,
-		Description: cmd.Description,
-		WorkflowID:  cmd.WorkflowID,
-		WorkspaceID: cmd.WorkspaceID,
-		Type:        cmd.Type,
-		ExposedOptions: submission.ExposedOptions{
-			ReadFromCache: cmd.ExposedOptions.ReadFromCache,
-		},
-		Inputs:  make(map[string]interface{}),
-		Outputs: make(map[string]interface{}),
+		Name:           cmd.Name,
+		Description:    cmd.Description,
+		WorkflowID:     cmd.WorkflowID,
+		WorkspaceID:    cmd.WorkspaceID,
+		Type:           cmd.Type,
+		ExposedOptions: cmd.ExposedOptions,
+		Inputs:         make(map[string]interface{}),
+		Outputs:        make(map[string]interface{}),
 	}
 
 	switch param.Type {

--- a/internal/context/submission/application/query/submission/object.go
+++ b/internal/context/submission/application/query/submission/object.go
@@ -13,7 +13,7 @@ type SubmissionItem struct {
 	WorkflowVersionID string
 	RunStatus         Status
 	Entity            *Entity
-	ExposedOptions    ExposedOptions
+	ExposedOptions    string
 	InOutMaterial     *InOutMaterial
 	WorkspaceID       string
 }
@@ -28,10 +28,6 @@ type Entity struct {
 type InOutMaterial struct {
 	InputsMaterial  string
 	OutputsMaterial string
-}
-
-type ExposedOptions struct {
-	ReadFromCache bool
 }
 
 type WorkflowVersion struct {

--- a/internal/context/submission/domain/run/event_submit_handler.go
+++ b/internal/context/submission/domain/run/event_submit_handler.go
@@ -65,6 +65,7 @@ func (e *EventHandlerSubmitRun) Handle(ctx context.Context, event *submission.Ev
 				BioosRunIDKey: run.ID,
 			},
 			WorkflowEngineParameters: event.RunConfig.WorkflowEngineParameters,
+			WorkflowURL:              event.RunConfig.MainWorkflowFilePath,
 		},
 		WorkflowAttachment: event.RunConfig.WorkflowContents,
 	})

--- a/internal/context/submission/domain/run/event_submit_handler.go
+++ b/internal/context/submission/domain/run/event_submit_handler.go
@@ -86,7 +86,7 @@ func (e *EventHandlerSubmitRun) markRunFailed(ctx context.Context, run *Run, mes
 	tempRun := run.Copy()
 	tempRun.Message = utils.PointString(message)
 	tempRun.FinishTime = utils.PointTime(time.Now())
-	if err := e.runRepo.Save(ctx, run); err != nil {
+	if err := e.runRepo.Save(ctx, tempRun); err != nil {
 		return apperrors.NewInternalError(err)
 	}
 	return nil

--- a/internal/context/submission/domain/submission/factory.go
+++ b/internal/context/submission/domain/submission/factory.go
@@ -20,7 +20,7 @@ type CreateSubmissionParam struct {
 	Type              string
 	Inputs            map[string]interface{}
 	Outputs           map[string]interface{}
-	ExposedOptions    ExposedOptions
+	ExposedOptions    string
 }
 
 func (p CreateSubmissionParam) validate() error {

--- a/internal/context/submission/domain/submission/object.go
+++ b/internal/context/submission/domain/submission/object.go
@@ -15,12 +15,8 @@ type Submission struct {
 	Type              string
 	Inputs            map[string]interface{}
 	Outputs           map[string]interface{}
-	ExposedOptions    ExposedOptions
+	ExposedOptions    string
 	Status            string
 	StartTime         time.Time
 	FinishTime        *time.Time
-}
-
-type ExposedOptions struct {
-	ReadFromCache bool `wes:"read_from_cache"`
 }

--- a/internal/context/submission/infrastructure/client/wes/client.go
+++ b/internal/context/submission/infrastructure/client/wes/client.go
@@ -121,7 +121,7 @@ func (i *impl) RunWorkflow(ctx context.Context, req *RunWorkflowRequest) (*RunWo
 		}
 		newReq = newReq.SetFileReader(workflowAttachment, filePath[len(prefix):], bytes.NewReader(decodeContent))
 	}
-	formData, err := runRequest2FormData(&req.RunRequest)
+	formData, err := runRequest2FormData(&req.RunRequest, prefix)
 	if err != nil {
 		return nil, newBadRequestError(err.Error())
 	}
@@ -224,7 +224,7 @@ func longestCommonPrefix(strs []string) string {
 }
 
 // runRequest2FormData ...
-func runRequest2FormData(req *RunRequest) (map[string]string, error) {
+func runRequest2FormData(req *RunRequest, prefix string) (map[string]string, error) {
 	formData := make(map[string]string)
 	if req.WorkflowParams != nil && len(req.WorkflowParams) > 0 {
 		workflowParamsInBytes, err := json.Marshal(req.WorkflowParams)
@@ -249,5 +249,6 @@ func runRequest2FormData(req *RunRequest) (map[string]string, error) {
 	}
 	formData[workflowType] = req.WorkflowType
 	formData[workflowTypeVersion] = req.WorkflowTypeVersion
+	formData[workflowURL] = req.WorkflowURL[len(prefix):]
 	return formData, nil
 }

--- a/internal/context/submission/infrastructure/client/wes/client.go
+++ b/internal/context/submission/infrastructure/client/wes/client.go
@@ -153,6 +153,7 @@ func (i *impl) GetRunLog(ctx context.Context, req *GetRunLogRequest) (*GetRunLog
 		if res.StatusCode >= 400 {
 			return nil, res.ErrorResp
 		}
+		UpdateLogsWithStdout(&res.GetRunLogResponse)
 		return &res.GetRunLogResponse, nil
 	} else if resp.IsError() {
 		return nil, res.ErrorResp
@@ -251,4 +252,12 @@ func runRequest2FormData(req *RunRequest, prefix string) (map[string]string, err
 	formData[workflowTypeVersion] = req.WorkflowTypeVersion
 	formData[workflowURL] = req.WorkflowURL[len(prefix):]
 	return formData, nil
+}
+
+// 标准WES API中没有log字段，在此处处理
+func UpdateLogsWithStdout(response *GetRunLogResponse) {
+	response.RunLog.Log = response.RunLog.Stdout
+	for index := range response.TaskLogs {
+		response.TaskLogs[index].Log = response.TaskLogs[index].Stdout
+	}
 }

--- a/internal/context/submission/infrastructure/client/wes/client.go
+++ b/internal/context/submission/infrastructure/client/wes/client.go
@@ -111,10 +111,6 @@ func (i *impl) RunWorkflow(ctx context.Context, req *RunWorkflowRequest) (*RunWo
 		return nil, newBadRequestError("workflowAttachment is empty")
 	}
 	prefix := longestCommonPrefix(filesPath)
-	// fix bug that func longestCommonPrefix() only return string level longestCommonPrefix
-	// However we need path level longestCommonPrefix.
-	// |   Main File  |Attachment File|String Level Prefix|Path Level Prefix|
-	// |/app/tasks.wdl| /app/test.wdl |      /app/t       |      /app/      |
 	if !strings.HasSuffix(prefix, "/") && len(prefix) > 0 {
 		prefix = fmt.Sprintf("%s/", path.Dir(prefix))
 	}
@@ -208,11 +204,16 @@ func longestCommonPrefix(strs []string) string {
 	prefix := strs[0][0:minStrLen]
 	for {
 		allFound := true
-		for i := 1; i < strsLen; i++ {
-			if strings.Index(strs[i], prefix) != 0 {
-				prefix = prefix[0 : len(prefix)-1]
-				allFound = false
-				break
+		if !strings.HasSuffix(prefix, "/") {
+			prefix = prefix[0 : len(prefix)-1]
+			allFound = false
+		} else {
+			for i := 1; i < strsLen; i++ {
+				if strings.Index(strs[i], prefix) != 0 {
+					prefix = prefix[0 : len(prefix)-1]
+					allFound = false
+					break
+				}
 			}
 		}
 		if allFound || len(prefix) == 0 {

--- a/internal/context/submission/infrastructure/client/wes/client.go
+++ b/internal/context/submission/infrastructure/client/wes/client.go
@@ -111,14 +111,11 @@ func (i *impl) RunWorkflow(ctx context.Context, req *RunWorkflowRequest) (*RunWo
 		return nil, newBadRequestError("workflowAttachment is empty")
 	}
 	prefix := longestCommonPrefix(filesPath)
-	if len(filesPath) == 1 {
-		prefix = fmt.Sprintf("%s/", path.Dir(filesPath[0]))
-	}
 	// fix bug that func longestCommonPrefix() only return string level longestCommonPrefix
 	// However we need path level longestCommonPrefix.
 	// |   Main File  |Attachment File|String Level Prefix|Path Level Prefix|
 	// |/app/tasks.wdl| /app/test.wdl |      /app/t       |      /app/      |
-	if !strings.HasSuffix(prefix, "/") {
+	if !strings.HasSuffix(prefix, "/") && len(prefix) > 0 {
 		prefix = fmt.Sprintf("%s/", path.Dir(prefix))
 	}
 	for _, filePath := range filesPath {
@@ -192,7 +189,11 @@ func longestCommonPrefix(strs []string) string {
 	case 0:
 		return ""
 	case 1:
-		return strs[0]
+		if strings.Contains(strs[0], "/") {
+			return fmt.Sprintf("%s/", path.Dir(strs[0]))
+		} else {
+			return ""
+		}
 	default:
 		if len(strs[0]) == 0 {
 			return ""

--- a/internal/context/submission/infrastructure/client/wes/model.go
+++ b/internal/context/submission/infrastructure/client/wes/model.go
@@ -64,6 +64,7 @@ type RunRequest struct {
 	WorkflowTypeVersion      string                 `json:"workflow_type_version"`
 	Tags                     map[string]interface{} `json:"tags"`
 	WorkflowEngineParameters map[string]interface{} `json:"workflow_engine_parameters"`
+	WorkflowURL              string                 `json:"workflow_url"`
 }
 
 // RunStatus ...

--- a/internal/context/submission/infrastructure/persistence/submission/sql/mapper.go
+++ b/internal/context/submission/infrastructure/persistence/submission/sql/mapper.go
@@ -23,9 +23,7 @@ func SubmissionPOToSubmissionDTO(ctx context.Context, submission *Submission) (*
 		WorkflowID:        submission.WorkflowID,
 		WorkflowVersionID: submission.WorkflowVersionID,
 		WorkspaceID:       submission.WorkspaceID,
-		ExposedOptions: query.ExposedOptions{
-			ReadFromCache: submission.ExposedOptions.ReadFromCache,
-		},
+		ExposedOptions:    submission.ExposedOptions,
 	}
 	if submission.FinishTime != nil {
 		item.FinishTime = utils.PointInt64(submission.FinishTime.Unix())
@@ -93,12 +91,10 @@ func SubmissionPOToSubmissionDO(ctx context.Context, sb *Submission) (*submissio
 		Type:              sb.Type,
 		Inputs:            sb.Inputs,
 		Outputs:           sb.Outputs,
-		ExposedOptions: submission.ExposedOptions{
-			ReadFromCache: sb.ExposedOptions.ReadFromCache,
-		},
-		Status:     sb.Status,
-		StartTime:  sb.StartTime,
-		FinishTime: sb.FinishTime,
+		ExposedOptions:    sb.ExposedOptions,
+		Status:            sb.Status,
+		StartTime:         sb.StartTime,
+		FinishTime:        sb.FinishTime,
 	}, nil
 }
 
@@ -123,11 +119,9 @@ func SubmissionDOToSubmissionPO(ctx context.Context, sb *submission.Submission) 
 		Inputs:            sb.Inputs,
 		Outputs:           sb.Outputs,
 		WorkspaceID:       sb.WorkspaceID,
-		ExposedOptions: ExposedOptions{
-			ReadFromCache: sb.ExposedOptions.ReadFromCache,
-		},
-		Status:     sb.Status,
-		StartTime:  sb.StartTime,
-		FinishTime: sb.FinishTime,
+		ExposedOptions:    sb.ExposedOptions,
+		Status:            sb.Status,
+		StartTime:         sb.StartTime,
+		FinishTime:        sb.FinishTime,
 	}, nil
 }

--- a/internal/context/submission/infrastructure/persistence/submission/sql/po.go
+++ b/internal/context/submission/infrastructure/persistence/submission/sql/po.go
@@ -24,15 +24,11 @@ type Submission struct {
 	Type              string                 `gorm:"type:varchar(32);not null"`
 	Inputs            map[string]interface{} `gorm:"serializer:json"`
 	Outputs           map[string]interface{} `gorm:"serializer:json"`
-	ExposedOptions    ExposedOptions         `gorm:"serializer:json"`
+	ExposedOptions    string                 `gorm:"type:longtext"`
 	Status            string                 `gorm:"type:varchar(32);not null"`
 	StartTime         time.Time              `gorm:"not null"`
 	FinishTime        *time.Time
 	UserID            *int64
-}
-
-type ExposedOptions struct {
-	ReadFromCache bool `json:"readFromCache"`
 }
 
 func (s *SubmissionModel) TableName() string {

--- a/internal/context/submission/interface/grpc/submission_mapper.go
+++ b/internal/context/submission/interface/grpc/submission_mapper.go
@@ -64,10 +64,8 @@ func queryEntityDTOToVO(entity *query.Entity) *pb.Entity {
 	}
 }
 
-func queryExposedOptionsDTOToVO(options query.ExposedOptions) *pb.ExposedOptions {
-	return &pb.ExposedOptions{
-		ReadFromCache: options.ReadFromCache,
-	}
+func queryExposedOptionsDTOToVO(options string) *pb.ExposedOptions {
+	return &pb.ExposedOptions{}
 }
 
 func queryInOutMaterialDTOToVO(material *query.InOutMaterial) *pb.InOutMaterial {
@@ -105,13 +103,9 @@ func commandEntityVoToDto(entity *pb.Entity) *command.Entity {
 	}
 }
 
-func commandExposedOptionsVoToDto(options *pb.ExposedOptions) command.ExposedOptions {
-	if options == nil {
-		return command.ExposedOptions{}
-	}
-	return command.ExposedOptions{
-		ReadFromCache: options.ReadFromCache,
-	}
+func commandExposedOptionsVoToDto(options *pb.ExposedOptions) string {
+	return ""
+
 }
 
 func commandInOutMaterialVoToDto(material *pb.InOutMaterial) *command.InOutMaterial {

--- a/internal/context/submission/interface/hertz/handlers/convert.go
+++ b/internal/context/submission/interface/hertz/handlers/convert.go
@@ -16,7 +16,7 @@ func createSubmissionVoToDto(req CreateSubmissionRequest) *submissioncommand.Cre
 		Description:    req.Description,
 		Type:           req.Type,
 		Entity:         commandEntityVoToDto(req.Entity),
-		ExposedOptions: commandExposedOptionsVoToDto(req.ExposedOptions),
+		ExposedOptions: req.ExposedOptions,
 		InOutMaterial:  commandInOutMaterialVoToDto(req.InOutMaterial),
 	}
 }
@@ -30,12 +30,6 @@ func commandEntityVoToDto(entity *Entity) *submissioncommand.Entity {
 		DataModelRowIDs: entity.DataModelRowIDs,
 		InputsTemplate:  entity.InputsTemplate,
 		OutputsTemplate: entity.OutputsTemplate,
-	}
-}
-
-func commandExposedOptionsVoToDto(options ExposedOptions) submissioncommand.ExposedOptions {
-	return submissioncommand.ExposedOptions{
-		ReadFromCache: options.ReadFromCache,
 	}
 }
 
@@ -109,7 +103,7 @@ func submissionItemDtoToVo(item *submissionquery.SubmissionItem) SubmissionItem 
 		WorkflowVersion: queryWorkflowVersionDtoToVo(item.WorkflowID, item.WorkflowVersionID),
 		RunStatus:       submissionQueryStatusDtoToVo(item.RunStatus),
 		Entity:          queryEntityDtoToVo(item.Entity),
-		ExposedOptions:  queryExposedOptionsDtoToVo(item.ExposedOptions),
+		ExposedOptions:  item.ExposedOptions,
 		InOutMaterial:   queryInOutMaterialDtoToVo(item.InOutMaterial),
 	}
 }
@@ -142,12 +136,6 @@ func queryEntityDtoToVo(entity *submissionquery.Entity) *Entity {
 		DataModelRowIDs: entity.DataModelRowIDs,
 		InputsTemplate:  entity.InputsTemplate,
 		OutputsTemplate: entity.OutputsTemplate,
-	}
-}
-
-func queryExposedOptionsDtoToVo(options submissionquery.ExposedOptions) ExposedOptions {
-	return ExposedOptions{
-		ReadFromCache: options.ReadFromCache,
 	}
 }
 

--- a/internal/context/submission/interface/hertz/handlers/submission_vo.go
+++ b/internal/context/submission/interface/hertz/handlers/submission_vo.go
@@ -7,7 +7,7 @@ type CreateSubmissionRequest struct {
 	Description    *string        `json:"description"`
 	Type           string         `json:"type"`
 	Entity         *Entity        `json:"entity"`
-	ExposedOptions ExposedOptions `json:"exposedOptions"`
+	ExposedOptions string         `json:"exposedOptions"`
 	InOutMaterial  *InOutMaterial `json:"inOutMaterial"`
 }
 
@@ -31,10 +31,6 @@ type Entity struct {
 type InOutMaterial struct {
 	InputsMaterial  string `json:"inputsMaterial"`
 	OutputsMaterial string `json:"outputsMaterial"`
-}
-
-type ExposedOptions struct {
-	ReadFromCache bool `json:"readFromCache"`
 }
 
 type CreateSubmissionResponse struct {
@@ -81,7 +77,7 @@ type SubmissionItem struct {
 	WorkflowVersion WorkflowVersion `json:"workflowVersion"`
 	RunStatus       Status          `json:"runStatus"`
 	Entity          *Entity         `json:"entity"`
-	ExposedOptions  ExposedOptions  `json:"exposedOptions"`
+	ExposedOptions  string          `json:"exposedOptions"`
 	InOutMaterial   *InOutMaterial  `json:"inOutMaterial"`
 }
 

--- a/internal/context/workspace/application/command/workflow/commands.go
+++ b/internal/context/workspace/application/command/workflow/commands.go
@@ -20,6 +20,9 @@ func NewCommands(repo workflow.Repository, workflowReadModel workflowquery.ReadM
 		workflowparser.WDL: workflowparser.WDLConfig{
 			WomtoolPath: womtoolPath,
 		},
+		workflowparser.CWL: workflowparser.CWLConfig{
+			CwltoolCmd: "cwltool",
+		},
 	}
 	workflowparser.InitWorkflowParserFactory(configs)
 	return &Commands{

--- a/internal/context/workspace/application/command/workflow/commands.go
+++ b/internal/context/workspace/application/command/workflow/commands.go
@@ -5,6 +5,7 @@ import (
 	"github.com/Bio-OS/bioos/internal/context/workspace/application/query/workspace"
 	"github.com/Bio-OS/bioos/internal/context/workspace/domain/workflow"
 	"github.com/Bio-OS/bioos/internal/context/workspace/infrastructure/eventbus"
+	"github.com/Bio-OS/bioos/internal/context/workspace/infrastructure/workflowparser"
 )
 
 type Commands struct {
@@ -14,7 +15,13 @@ type Commands struct {
 }
 
 func NewCommands(repo workflow.Repository, workflowReadModel workflowquery.ReadModel, factory *workflow.Factory, workspaceReadModel workspace.WorkspaceReadModel, bus eventbus.EventBus, womtoolPath string) *Commands {
-	service := workflow.NewService(repo, workflowReadModel, bus, factory, womtoolPath)
+	service := workflow.NewService(repo, workflowReadModel, bus, factory)
+	configs := map[string]workflowparser.ParserConfig{
+		workflowparser.WDL: workflowparser.WDLConfig{
+			WomtoolPath: womtoolPath,
+		},
+	}
+	workflowparser.InitWorkflowParserFactory(configs)
 	return &Commands{
 		Create: NewCreateHandler(service, workflowReadModel, workspaceReadModel),
 		Delete: NewDeleteHandler(service, workspaceReadModel),

--- a/internal/context/workspace/domain/workflow/consts.go
+++ b/internal/context/workspace/domain/workflow/consts.go
@@ -18,6 +18,13 @@ const (
 )
 
 const (
+	WorkflowLanguageWDL       = "WDL"
+	WorkflowLanguageCWL       = "CWL"
+	WorkflowLanguageSnakemake = "SMK"
+	WorkflowLanguageNextflow  = "NFL"
+)
+
+const (
 	Language         = "WDL"
 	VersionRegexpStr = "^version\\s+([\\w-._]+)"
 )

--- a/internal/context/workspace/domain/workflow/factory.go
+++ b/internal/context/workspace/domain/workflow/factory.go
@@ -83,6 +83,10 @@ func (p VersionOption) validate() error {
 			return apperrors.NewInvalidError("tag")
 		}
 	}
+	// 增加language validation
+	if p.Language != WorkflowLanguageCWL && p.Language != WorkflowLanguageWDL && p.Language != WorkflowLanguageNextflow && p.Language != WorkflowLanguageSnakemake {
+		return apperrors.NewInvalidError("Language")
+	}
 	return nil
 }
 

--- a/internal/context/workspace/domain/workflow/object.go
+++ b/internal/context/workspace/domain/workflow/object.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"encoding/json"
 	"time"
 
 	applog "github.com/Bio-OS/bioos/pkg/log"
@@ -141,6 +142,16 @@ func (v *WorkflowVersion) AddFile(param *FileParam) (*WorkflowFile, error) {
 	return file, nil
 }
 
+func workflowParamPOToDO(paramStr string) ([]WorkflowParam, error) {
+	var params []WorkflowParam
+	if len(paramStr) > 0 {
+		if err := json.Unmarshal([]byte(paramStr), &params); err != nil {
+			return nil, err
+		}
+	}
+	return params, nil
+}
+
 // WorkflowFile workflow file
 type WorkflowFile struct {
 	// ID is the unique identifier of the workflow file
@@ -153,4 +164,14 @@ type WorkflowFile struct {
 	CreatedAt time.Time
 	// UpdatedAt is the update time of workflow file
 	UpdatedAt time.Time
+}
+
+func fileParamPOToDO(paramStr string) ([]FileParam, error) {
+	var params []FileParam
+	if len(paramStr) > 0 {
+		if err := json.Unmarshal([]byte(paramStr), &params); err != nil {
+			return nil, err
+		}
+	}
+	return params, nil
 }

--- a/internal/context/workspace/domain/workflow/service.go
+++ b/internal/context/workspace/domain/workflow/service.go
@@ -26,14 +26,14 @@ type service struct {
 	factory    *Factory
 }
 
-func NewService(repo Repository, readModel workflow.ReadModel, bus eventbus.EventBus, factory *Factory, womtoolPath string) Service {
+func NewService(repo Repository, readModel workflow.ReadModel, bus eventbus.EventBus, factory *Factory) Service {
 	svc := &service{
 		readModel:  readModel,
 		repository: repo,
 		eventbus:   bus,
 		factory:    factory,
 	}
-	svc.subscribeEvents(womtoolPath)
+	svc.subscribeEvents()
 	return svc
 }
 
@@ -200,7 +200,7 @@ func (s *service) UpdateVersion(ctx context.Context, workspaceID string, workflo
 	return nil
 }
 
-func (s *service) subscribeEvents(womtoolPath string) {
+func (s *service) subscribeEvents() {
 	s.eventbus.Subscribe(WorkflowVersionAdded, eventbus.EventHandlerFunc(func(ctx context.Context, payload string) (err error) {
 		applog.Infow("start to consume workflow version added event", "payload", payload)
 
@@ -209,7 +209,7 @@ func (s *service) subscribeEvents(womtoolPath string) {
 			return err
 		}
 
-		handler := NewWorkflowVersionAddedHandler(s.repository, womtoolPath)
+		handler := NewWorkflowVersionAddedHandler(s.repository)
 		return handler.Handle(ctx, event)
 	}))
 

--- a/internal/context/workspace/infrastructure/workflowparser/cwlparser.go
+++ b/internal/context/workspace/infrastructure/workflowparser/cwlparser.go
@@ -10,12 +10,13 @@ import (
 	"path"
 	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/Bio-OS/bioos/internal/context/workspace/interface/grpc/proto"
 	apperrors "github.com/Bio-OS/bioos/pkg/errors"
 	applog "github.com/Bio-OS/bioos/pkg/log"
 	"github.com/Bio-OS/bioos/pkg/utils/exec"
-	"gopkg.in/yaml.v2"
 )
 
 type CWLConfig struct {
@@ -74,7 +75,7 @@ func (cwl *CWLParser) ValidateWorkflowFiles(ctx context.Context, baseDir, mainWo
 		return "", err
 	}
 	depsResultLines := strings.Split(string(depsResults), "\n")
-	if len(validateResultLines) < 3 {
+	if len(depsResultLines) < 3 {
 		return "", proto.ErrorWorkflowValidateError("fail to check deps")
 	}
 	jsonContent := strings.Join(depsResultLines[2:], "\n")
@@ -110,49 +111,69 @@ func (cwl *CWLParser) ValidateWorkflowFiles(ctx context.Context, baseDir, mainWo
 
 func (cwl *CWLParser) GetWorkflowInputs(ctx context.Context, WorkflowFilePath string) (string, error) {
 	params := make([]WorkflowParam, 0)
-	templateResult, err := exec.Exec(ctx, CommandExecuteTimeout, cwl.Config.CwltoolCmd, "--make-template", WorkflowFilePath)
+	rdfResult, err := exec.Exec(ctx, CommandExecuteTimeout, cwl.Config.CwltoolCmd, "--print-rdf", WorkflowFilePath)
 	if err != nil {
 		return "", err
 	}
-	templateResultLines := strings.Split(string(templateResult), "\n")
-	yamlContent := strings.Join(templateResultLines[2:], "\n")
 
-	var yamlData map[string]interface{}
-	if err := yaml.Unmarshal([]byte(yamlContent), &yamlData); err != nil {
-		return "", err
+	inputsRe := regexp.MustCompile(`(?s)cwl:inputs\s(.*?)\s;`) // 找到所有输入文件
+	inputs := inputsRe.FindAllStringSubmatch(string(rdfResult), -1)
+	var inputFiles []string
+	if len(inputs) > 0 {
+		for _, value := range inputs {
+			files := strings.Split(value[1], ",")
+			for _, file := range files {
+				trimmedFile := strings.TrimSpace(file)
+				inputFiles = append(inputFiles, trimmedFile)
+			}
+		}
+	} else {
+		return "", nil
 	}
 
-	for key, value := range yamlData {
-		param := WorkflowParam{Name: key}
+	sectionRe := regexp.MustCompile(`[\s]*\r?\n[\s]*\r?\n[\s]*`) // 输出结果分块
+	rdfResultSection := sectionRe.Split(string(rdfResult), -1)
 
-		keyWithColon := key + ":"
-		startIndex := strings.Index(yamlContent, keyWithColon)
-		if startIndex == -1 {
-			continue
+	for _, value := range rdfResultSection { // 遍历各个分块，找到描述对应文件的部分
+		if containsAny(value, inputFiles) && !strings.Contains(value, "cwl:inputs") {
+			param := WorkflowParam{}
+			nameRe := regexp.MustCompile(`#(.*?)> `)
+			nameMatch := nameRe.FindStringSubmatch(value)
+			if len(nameMatch) > 1 {
+				param.Name = nameMatch[1]
+				lastSlashIndex := strings.LastIndex(param.Name, "/") // 某些情况下会多一级斜杠
+				if lastSlashIndex != -1 {
+					param.Name = param.Name[lastSlashIndex+1:]
+				}
+			} else {
+				continue
+			}
+
+			param.Optional = strings.Contains(value, "sld:null")
+
+			typeRe := regexp.MustCompile(`sld:type\s+.*?([^:\s,.]+)[\s,.]`)
+			typeMatch := typeRe.FindAllStringSubmatch(value, -1)
+			if len(typeMatch) > 0 {
+				if strings.Contains(typeMatch[0][1], "[") { // Array Enum Record等类型，文本格式与其他类型不同
+					param.Type = upperCaseFirstLetter(typeMatch[len(typeMatch)-1][1])
+				} else {
+					param.Type = upperCaseFirstLetter(typeMatch[0][1])
+				}
+			} else {
+				continue
+			}
+
+			defaultRe := regexp.MustCompile(`cwl:default\s+.*?([^;]+)\s`)
+			defaultMatch := defaultRe.FindStringSubmatch(value)
+			if len(defaultMatch) > 1 && param.Type != "Record" { // Record类型暂时无法输出默认值
+				if param.Type == "Array" {
+					fmt.Println("[" + removeSpacesAndNewlines(defaultMatch[1]) + "]")
+				} else {
+					param.Default = defaultMatch[1]
+				}
+			}
+			params = append(params, param)
 		}
-		endIndex := strings.Index(yamlContent[startIndex:], "\n")
-		var paramDesc string
-		if endIndex == -1 {
-			paramDesc = yamlContent[startIndex:]
-		} else {
-			paramDesc = yamlContent[startIndex:endIndex]
-		}
-
-		reType := regexp.MustCompile(`type\s+'([^']*)'`)
-		matchType := reType.FindStringSubmatch(paramDesc)
-		if matchType != nil {
-			param.Type = matchType[1]
-		} else {
-			continue
-		}
-
-		param.Optional = strings.Contains(paramDesc, "(optional)")
-
-		if strings.Contains(paramDesc, "default value") {
-			param.Default = value.(string)
-		}
-
-		params = append(params, param)
 	}
 
 	return workflowParamDoToPO(params)
@@ -164,26 +185,56 @@ func (cwl *CWLParser) GetWorkflowOutputs(ctx context.Context, WorkflowFilePath s
 	if err != nil {
 		return "", err
 	}
-	rdfResultSection := strings.Split(string(rdfResult), "\n\n")
-	for _, value := range rdfResultSection {
-		if strings.Contains(value, "cwl:outputBinding") {
-			param := WorkflowParam{Optional: false}
-			re := regexp.MustCompile(`sld:type\s+([^:\s]+):`)
-			match := re.FindStringSubmatch(value)
-			if len(match) > 1 {
-				param.Type = match[1]
+
+	outputsRe := regexp.MustCompile(`(?s)cwl:outputs\s(.*?)\s;`) // 找到所有输出文件
+	outputs := outputsRe.FindAllStringSubmatch(string(rdfResult), -1)
+	var outputFiles []string
+	if len(outputs) > 0 {
+		for _, value := range outputs {
+			files := strings.Split(value[1], ",")
+			for _, file := range files {
+				trimmedFile := strings.TrimSpace(file)
+				outputFiles = append(outputFiles, trimmedFile)
+			}
+		}
+	} else {
+		return "", nil
+	}
+
+	sectionRe := regexp.MustCompile(`[\s]*\r?\n[\s]*\r?\n[\s]*`) // 输出结果分块
+	rdfResultSection := sectionRe.Split(string(rdfResult), -1)
+
+	for _, value := range rdfResultSection { // 遍历各个分块，找到描述对应文件的部分
+		if containsAny(value, outputFiles) && !strings.Contains(value, "cwl:outputs") {
+			param := WorkflowParam{}
+			nameRe := regexp.MustCompile(`#(.*?)> `)
+			nameMatch := nameRe.FindStringSubmatch(value)
+			if len(nameMatch) > 1 {
+				param.Name = nameMatch[1]
+				lastSlashIndex := strings.LastIndex(param.Name, "/") // 某些情况下会多一级斜杠
+				if lastSlashIndex != -1 {
+					param.Name = param.Name[lastSlashIndex+1:]
+				}
 			} else {
 				continue
 			}
 
-			re2 := regexp.MustCompile(`\/(.*?)> rdfs:comment`)
-			match2 := re2.FindStringSubmatch(value)
-			if len(match2) > 1 {
-				param.Name = match[1]
+			param.Optional = true // 输出全部为Optional
+
+			typeRe := regexp.MustCompile(`sld:type\s+.*?([^:\s,.]+)[\s,.]`)
+			typeMatch := typeRe.FindAllStringSubmatch(value, -1)
+			if len(typeMatch) > 0 {
+				if strings.Contains(typeMatch[0][1], "[") { // Array Enum Record等类型，文本格式与其他类型不同
+					param.Type = upperCaseFirstLetter(typeMatch[len(typeMatch)-1][1])
+				} else {
+					param.Type = upperCaseFirstLetter(typeMatch[0][1])
+				}
 			} else {
 				continue
 			}
-			param.Default = value
+
+			// 不处理default
+
 			params = append(params, param)
 		}
 	}
@@ -203,4 +254,29 @@ type CWLFile struct {
 	Basename       string    `json:"basename,omitempty"`       // omitempty保证如果字段为空，则在JSON中省略
 	Nameroot       string    `json:"nameroot,omitempty"`
 	Nameext        string    `json:"nameext,omitempty"`
+}
+
+func containsAny(str string, substrings []string) bool {
+	for _, substr := range substrings {
+		if strings.Contains(str, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func upperCaseFirstLetter(s string) string {
+	if s == "" {
+		return ""
+	}
+	r, size := utf8.DecodeRuneInString(s)
+	return string(unicode.ToUpper(r)) + s[size:]
+}
+
+func removeSpacesAndNewlines(input string) string {
+	parts := strings.Split(input, ",")
+	for i, part := range parts {
+		parts[i] = strings.TrimSpace(part)
+	}
+	return strings.Join(parts, ",")
 }

--- a/internal/context/workspace/infrastructure/workflowparser/cwlparser.go
+++ b/internal/context/workspace/infrastructure/workflowparser/cwlparser.go
@@ -88,7 +88,7 @@ func (cwl *CWLParser) ValidateWorkflowFiles(ctx context.Context, baseDir, mainWo
 	depsFiles := depsFileRe.FindAllStringSubmatch(string(depsResults), -1)
 
 	workflowFiles := []string{}
-	if len(depsFiles) > 1 {
+	if len(depsFiles) > 0 {
 		scriptDir := filepath.Dir(mainWorkflowPath)
 		for _, value := range depsFiles {
 			joinedPath := filepath.Join(scriptDir, value[1])
@@ -105,7 +105,7 @@ func (cwl *CWLParser) ValidateWorkflowFiles(ctx context.Context, baseDir, mainWo
 			}
 		}
 	} else {
-		return "", err
+		return "", apperrors.NewInternalError(fmt.Errorf("no valid workflow files"))
 	}
 
 	params := make([]FileParam, 0)

--- a/internal/context/workspace/infrastructure/workflowparser/cwlparser.go
+++ b/internal/context/workspace/infrastructure/workflowparser/cwlparser.go
@@ -1,0 +1,206 @@
+package workflowparser
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/Bio-OS/bioos/internal/context/workspace/interface/grpc/proto"
+	apperrors "github.com/Bio-OS/bioos/pkg/errors"
+	applog "github.com/Bio-OS/bioos/pkg/log"
+	"github.com/Bio-OS/bioos/pkg/utils/exec"
+	"gopkg.in/yaml.v2"
+)
+
+type CWLConfig struct {
+	CwltoolCmd string
+}
+
+type CWLParser struct {
+	Config CWLConfig
+}
+
+func NewCWLParser(config CWLConfig) *CWLParser {
+	return &CWLParser{Config: config}
+}
+
+func (cwl *CWLParser) ParseWorkflowVersion(_ context.Context, mainWorkflowPath string) (string, error) {
+	versionRegexp := regexp.MustCompile(CWLVersionRegexpStr)
+	file, err := os.Open(mainWorkflowPath)
+	if err != nil {
+		applog.Errorw("fail to open main workflow file", "err", err)
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		matched := versionRegexp.FindStringSubmatch(line)
+		if len(matched) >= 2 {
+			applog.Infow("version regexp matched", "matched", matched)
+			return matched[1], nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "v1.0", nil
+}
+
+func (cwl *CWLParser) ValidateWorkflowFiles(ctx context.Context, baseDir, mainWorkflowPath string) (string, error) {
+	applog.Infow("start to validate files", "mainWorkflowPath", mainWorkflowPath)
+	validateResult, err := exec.Exec(ctx, CommandExecuteTimeout, cwl.Config.CwltoolCmd, "--validate", path.Join(baseDir, mainWorkflowPath))
+	if err != nil {
+		applog.Errorw("fail to validate workflow", "err", err, "result", string(validateResult))
+		return "", apperrors.NewInternalError(fmt.Errorf("validate workflow failed"))
+	}
+	validateResultLines := strings.Split(string(validateResult), "\n")
+	applog.Infow("validate result", "result", validateResultLines)
+	// parse and save workflow files
+	if len(validateResultLines) < 3 || !strings.Contains(validateResultLines[2], "is valid CWL") {
+		return "", proto.ErrorWorkflowValidateError("fail to validate workflow")
+	}
+
+	depsResults, err := exec.Exec(ctx, CommandExecuteTimeout, cwl.Config.CwltoolCmd, "--print-deps", path.Join(baseDir, mainWorkflowPath))
+	if err != nil {
+		return "", err
+	}
+	depsResultLines := strings.Split(string(depsResults), "\n")
+	if len(validateResultLines) < 3 {
+		return "", proto.ErrorWorkflowValidateError("fail to check deps")
+	}
+	jsonContent := strings.Join(depsResultLines[2:], "\n")
+	var file CWLFile
+	err = json.Unmarshal([]byte(jsonContent), &file)
+	if err != nil {
+		return "", err
+	}
+
+	workflowFiles := []string{mainWorkflowPath}
+	// need to start from line 2(start with line 0)
+	for i := 0; i < len(file.SecondaryFiles); i++ {
+		workflowFiles = append(workflowFiles, file.SecondaryFiles[i].Location)
+	}
+	params := make([]FileParam, 0)
+	for _, relPath := range workflowFiles {
+		input, err := os.ReadFile(path.Join(baseDir, relPath))
+		if err != nil {
+			applog.Errorw("fail to read file", "err", err)
+			return "", apperrors.NewInternalError(err)
+		}
+
+		encodedContent := base64.StdEncoding.EncodeToString(input)
+
+		param := FileParam{
+			Path:    relPath,
+			Content: encodedContent,
+		}
+		params = append(params, param)
+	}
+	return fileParamDoToPO(params)
+}
+
+func (cwl *CWLParser) GetWorkflowInputs(ctx context.Context, WorkflowFilePath string) (string, error) {
+	params := make([]WorkflowParam, 0)
+	templateResult, err := exec.Exec(ctx, CommandExecuteTimeout, cwl.Config.CwltoolCmd, "--make-template", WorkflowFilePath)
+	if err != nil {
+		return "", err
+	}
+	templateResultLines := strings.Split(string(templateResult), "\n")
+	yamlContent := strings.Join(templateResultLines[2:], "\n")
+
+	var yamlData map[string]interface{}
+	if err := yaml.Unmarshal([]byte(yamlContent), &yamlData); err != nil {
+		return "", err
+	}
+
+	for key, value := range yamlData {
+		param := WorkflowParam{Name: key}
+
+		keyWithColon := key + ":"
+		startIndex := strings.Index(yamlContent, keyWithColon)
+		if startIndex == -1 {
+			continue
+		}
+		endIndex := strings.Index(yamlContent[startIndex:], "\n")
+		var paramDesc string
+		if endIndex == -1 {
+			paramDesc = yamlContent[startIndex:]
+		} else {
+			paramDesc = yamlContent[startIndex:endIndex]
+		}
+
+		reType := regexp.MustCompile(`type\s+'([^']*)'`)
+		matchType := reType.FindStringSubmatch(paramDesc)
+		if matchType != nil {
+			param.Type = matchType[1]
+		} else {
+			continue
+		}
+
+		param.Optional = strings.Contains(paramDesc, "(optional)")
+
+		if strings.Contains(paramDesc, "default value") {
+			param.Default = value.(string)
+		}
+
+		params = append(params, param)
+	}
+
+	return workflowParamDoToPO(params)
+}
+
+func (cwl *CWLParser) GetWorkflowOutputs(ctx context.Context, WorkflowFilePath string) (string, error) {
+	params := make([]WorkflowParam, 0)
+	rdfResult, err := exec.Exec(ctx, CommandExecuteTimeout, cwl.Config.CwltoolCmd, "--print-rdf", WorkflowFilePath)
+	if err != nil {
+		return "", err
+	}
+	rdfResultSection := strings.Split(string(rdfResult), "\n\n")
+	for _, value := range rdfResultSection {
+		if strings.Contains(value, "cwl:outputBinding") {
+			param := WorkflowParam{Optional: false}
+			re := regexp.MustCompile(`sld:type\s+([^:\s]+):`)
+			match := re.FindStringSubmatch(value)
+			if len(match) > 1 {
+				param.Type = match[1]
+			} else {
+				continue
+			}
+
+			re2 := regexp.MustCompile(`\/(.*?)> rdfs:comment`)
+			match2 := re2.FindStringSubmatch(value)
+			if len(match2) > 1 {
+				param.Name = match[1]
+			} else {
+				continue
+			}
+			param.Default = value
+			params = append(params, param)
+		}
+	}
+
+	return workflowParamDoToPO(params)
+}
+
+func (cwl *CWLParser) GetWorkflowGraph(ctx context.Context, WorkflowFilePath string) (string, error) {
+	return "", nil
+}
+
+type CWLFile struct {
+	Class          string    `json:"class"`
+	Location       string    `json:"location"`
+	Format         string    `json:"format"`
+	SecondaryFiles []CWLFile `json:"secondaryFiles,omitempty"` // 使用相同的结构体表示嵌套的secondaryFiles数组
+	Basename       string    `json:"basename,omitempty"`       // omitempty保证如果字段为空，则在JSON中省略
+	Nameroot       string    `json:"nameroot,omitempty"`
+	Nameext        string    `json:"nameext,omitempty"`
+}

--- a/internal/context/workspace/infrastructure/workflowparser/object.go
+++ b/internal/context/workspace/infrastructure/workflowparser/object.go
@@ -2,6 +2,13 @@ package workflowparser
 
 import (
 	"encoding/json"
+	"time"
+)
+
+const (
+	CommandExecuteTimeout = time.Minute * 3
+	WDLVersionRegexpStr   = "^version\\s+([\\w-._]+)"
+	CWLVersionRegexpStr   = "^cwlVersion\\s+([\\w-._]+)"
 )
 
 type WorkflowParam struct {

--- a/internal/context/workspace/infrastructure/workflowparser/object.go
+++ b/internal/context/workspace/infrastructure/workflowparser/object.go
@@ -1,0 +1,65 @@
+package workflowparser
+
+import (
+	"encoding/json"
+)
+
+type WorkflowParam struct {
+	// Name param name
+	Name string `json:"name"`
+	// Type param type
+	Type string `json:"type"`
+	// Optional param is optional
+	Optional bool `json:"optional"`
+	// Default param default value
+	Default string `json:"default,omitempty"`
+}
+
+func workflowParamPOToDO(paramStr string) ([]WorkflowParam, error) {
+	var params []WorkflowParam
+	if len(paramStr) > 0 {
+		if err := json.Unmarshal([]byte(paramStr), &params); err != nil {
+			return nil, err
+		}
+	}
+	return params, nil
+}
+
+func workflowParamDoToPO(params []WorkflowParam) (string, error) {
+	if len(params) == 0 {
+		return "", nil
+	}
+
+	paramBytes, err := json.Marshal(params)
+	if err != nil {
+		return "", err
+	}
+	return string(paramBytes), nil
+}
+
+type FileParam struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+func fileParamPOToDO(paramStr string) ([]FileParam, error) {
+	var params []FileParam
+	if len(paramStr) > 0 {
+		if err := json.Unmarshal([]byte(paramStr), &params); err != nil {
+			return nil, err
+		}
+	}
+	return params, nil
+}
+
+func fileParamDoToPO(params []FileParam) (string, error) {
+	if len(params) == 0 {
+		return "", nil
+	}
+
+	paramBytes, err := json.Marshal(params)
+	if err != nil {
+		return "", err
+	}
+	return string(paramBytes), nil
+}

--- a/internal/context/workspace/infrastructure/workflowparser/wdlparser.go
+++ b/internal/context/workspace/infrastructure/workflowparser/wdlparser.go
@@ -1,0 +1,200 @@
+package workflowparser
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Bio-OS/bioos/internal/context/workspace/interface/grpc/proto"
+	apperrors "github.com/Bio-OS/bioos/pkg/errors"
+	applog "github.com/Bio-OS/bioos/pkg/log"
+	"github.com/Bio-OS/bioos/pkg/utils/exec"
+)
+
+type WDLConfig struct {
+	WomtoolPath string
+}
+
+type WDLParser struct {
+	Config WDLConfig
+}
+
+func NewWDLParser(config WDLConfig) *WDLParser {
+	return &WDLParser{Config: config}
+}
+
+const (
+	CommandExecuteTimeout = time.Minute * 3
+	Language              = "WDL"
+	VersionRegexpStr      = "^version\\s+([\\w-._]+)"
+)
+
+func (wdl *WDLParser) ParseWorkflowVersion(_ context.Context, mainWorkflowPath string) (string, error) {
+	versionRegexp := regexp.MustCompile(VersionRegexpStr)
+	file, err := os.Open(mainWorkflowPath)
+	if err != nil {
+		applog.Errorw("fail to open main workflow file", "err", err)
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		matched := versionRegexp.FindStringSubmatch(line)
+		if matched != nil && len(matched) >= 2 {
+			applog.Infow("version regexp matched", "matched", matched)
+			return matched[1], nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "draft-2", nil
+}
+
+func (wdl *WDLParser) ValidateWorkflowFiles(ctx context.Context, baseDir, mainWorkflowPath string) (string, error) {
+	applog.Infow("start to validate files", "mainWorkflowPath", mainWorkflowPath)
+	validateResult, err := exec.Exec(ctx, CommandExecuteTimeout, "java", "-jar", wdl.Config.WomtoolPath, "validate", path.Join(baseDir, mainWorkflowPath), "-l")
+	if err != nil {
+		applog.Errorw("fail to validate workflow", "err", err, "result", string(validateResult))
+		return "", apperrors.NewInternalError(fmt.Errorf("validate workflow failed"))
+	}
+	validateResultLines := strings.Split(string(validateResult), "\n")
+	applog.Infow("validate result", "result", validateResultLines)
+	// parse and save workflow files
+	if len(validateResultLines) < 2 || strings.ToLower(validateResultLines[0]) != "success!" {
+		return "", proto.ErrorWorkflowValidateError("fail to validate workflow")
+	}
+	workflowFiles := []string{mainWorkflowPath}
+	// need to start from line 2(start with line 0)
+	for i := 2; i < len(validateResultLines); i++ {
+		absPath := validateResultLines[i]
+		if len(absPath) == 0 {
+			continue
+		}
+		// validate file
+		if _, err := os.Stat(absPath); err == nil {
+			// in mac absPath was prefix with /private
+			relPath, err := filepath.Rel(baseDir, absPath[strings.LastIndex(absPath, baseDir):])
+			if err != nil {
+				return "", apperrors.NewInternalError(err)
+			}
+			applog.Infow("file path", "baseDir", baseDir, "absPath", absPath, "relPath", relPath)
+			workflowFiles = append(workflowFiles, relPath)
+		}
+	}
+	params := make([]FileParam, 0)
+	for _, relPath := range workflowFiles {
+		input, err := os.ReadFile(path.Join(baseDir, relPath))
+		if err != nil {
+			applog.Errorw("fail to read file", "err", err)
+			return "", apperrors.NewInternalError(err)
+		}
+
+		encodedContent := base64.StdEncoding.EncodeToString(input)
+
+		param := FileParam{
+			Path:    relPath,
+			Content: encodedContent,
+		}
+		params = append(params, param)
+	}
+	return fileParamDoToPO(params)
+}
+
+func (wdl *WDLParser) GetWorkflowInputs(ctx context.Context, WorkflowFilePath string) (string, error) {
+	results, err := wdl.GetWorkflowParams(ctx, "java", "-jar", wdl.Config.WomtoolPath, "inputs", WorkflowFilePath)
+	if err != nil {
+		return "", err
+	}
+	return workflowParamDoToPO(results)
+}
+
+func (wdl *WDLParser) GetWorkflowOutputs(ctx context.Context, WorkflowFilePath string) (string, error) {
+	results, err := wdl.GetWorkflowParams(ctx, "java", "-jar", wdl.Config.WomtoolPath, "outputs", WorkflowFilePath)
+	if err != nil {
+		return "", err
+	}
+	return workflowParamDoToPO(results)
+}
+
+func (wdl *WDLParser) GetWorkflowParams(ctx context.Context, name string, arg ...string) ([]WorkflowParam, error) {
+	params := make([]WorkflowParam, 0)
+	outputsResult, err := exec.Exec(ctx, CommandExecuteTimeout, name, arg...)
+	if err != nil {
+		return params, err
+	}
+	var outputsMap map[string]string
+	if err := json.Unmarshal(outputsResult, &outputsMap); err != nil {
+		return params, err
+	}
+
+	for paramName, value := range outputsMap {
+		paramType, optional, defaultValue := parseWorkflowParamValue(value)
+		param := WorkflowParam{
+			Name:     paramName,
+			Type:     paramType,
+			Optional: optional,
+		}
+		if defaultValue != nil {
+			param.Default = *defaultValue
+		}
+		params = append(params, param)
+	}
+	// keep the return sort stable
+	sort.Slice(params, func(i, j int) bool {
+		return params[i].Name < params[j].Name
+	})
+	return params, nil
+}
+
+func (wdl *WDLParser) GetWorkflowGraph(ctx context.Context, WorkflowFilePath string) (string, error) {
+	graph, err := exec.Exec(ctx, CommandExecuteTimeout, "java", "-jar", wdl.Config.WomtoolPath, "graph", WorkflowFilePath)
+	if err != nil {
+		return "", err
+	}
+
+	return string(graph), nil
+}
+
+func parseWorkflowParamValue(value string) (paramType string, optional bool, defaultValue *string) {
+	splitByLeftBracket := strings.SplitN(value, "(", 2)
+	paramType = strings.TrimSpace(splitByLeftBracket[0])
+	if len(splitByLeftBracket) == 1 {
+		return paramType, false, nil
+	}
+
+	extraInfo := strings.TrimSuffix(splitByLeftBracket[1], ")")
+	splitByComma := strings.SplitN(extraInfo, ",", 2)
+	if strings.TrimSpace(splitByComma[0]) == "optional" {
+		optional = true
+	}
+	if len(splitByComma) == 1 {
+		return paramType, optional, nil
+	}
+
+	defaultInfo := strings.TrimSpace(splitByComma[1])
+	splitByEqual := strings.SplitN(defaultInfo, "=", 2)
+	if len(splitByEqual) != 2 || strings.ToLower(strings.TrimSpace(splitByEqual[0])) != "default" {
+		return paramType, optional, nil
+	}
+	rawDefaultValue := strings.TrimSpace(splitByEqual[1])
+	defaultValue = new(string)
+	if strings.HasPrefix(rawDefaultValue, `"`) && strings.HasSuffix(rawDefaultValue, `"`) { // String type
+		_ = json.Unmarshal([]byte(rawDefaultValue), defaultValue) // escape, never error
+	} else {
+		*defaultValue = rawDefaultValue
+	}
+	return paramType, optional, defaultValue
+}

--- a/internal/context/workspace/infrastructure/workflowparser/wdlparser.go
+++ b/internal/context/workspace/infrastructure/workflowparser/wdlparser.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/Bio-OS/bioos/internal/context/workspace/interface/grpc/proto"
 	apperrors "github.com/Bio-OS/bioos/pkg/errors"
@@ -32,14 +31,8 @@ func NewWDLParser(config WDLConfig) *WDLParser {
 	return &WDLParser{Config: config}
 }
 
-const (
-	CommandExecuteTimeout = time.Minute * 3
-	Language              = "WDL"
-	VersionRegexpStr      = "^version\\s+([\\w-._]+)"
-)
-
 func (wdl *WDLParser) ParseWorkflowVersion(_ context.Context, mainWorkflowPath string) (string, error) {
-	versionRegexp := regexp.MustCompile(VersionRegexpStr)
+	versionRegexp := regexp.MustCompile(WDLVersionRegexpStr)
 	file, err := os.Open(mainWorkflowPath)
 	if err != nil {
 		applog.Errorw("fail to open main workflow file", "err", err)

--- a/internal/context/workspace/infrastructure/workflowparser/workflowparser.go
+++ b/internal/context/workspace/infrastructure/workflowparser/workflowparser.go
@@ -1,0 +1,77 @@
+package workflowparser
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+const (
+	WDL       = "WDL"
+	CWL       = "CWL"
+	Snakemake = "SMK"
+	Nextflow  = "NFL"
+)
+
+type ParserConfig interface{}
+
+type WorkflowParser interface {
+	ParseWorkflowVersion(ctx context.Context, mainWorkflowPath string) (string, error)
+	ValidateWorkflowFiles(ctx context.Context, baseDir, mainWorkflowPath string) (string, error)
+	GetWorkflowInputs(ctx context.Context, WorkflowFilePath string) (string, error)
+	GetWorkflowOutputs(ctx context.Context, WorkflowFilePath string) (string, error)
+	GetWorkflowGraph(ctx context.Context, WorkflowFilePath string) (string, error)
+}
+
+var parserCreateFunc = make(map[string]func(ParserConfig) WorkflowParser)
+
+func RegisterParseCreateFunc(workflowType string, function func(ParserConfig) WorkflowParser) {
+	parserCreateFunc[workflowType] = function
+}
+
+func init() {
+	RegisterParseCreateFunc(WDL, func(config ParserConfig) WorkflowParser {
+		wdlConfig, ok := config.(WDLConfig)
+		if !ok {
+			panic("Invalid config type for WDL parser")
+		}
+		return NewWDLParser(wdlConfig)
+	})
+}
+
+var (
+	instance *WorkflowParserFactory
+	once     sync.Once
+)
+
+type WorkflowParserFactory struct {
+	parsers map[string]WorkflowParser
+}
+
+func InitWorkflowParserFactory(configs map[string]ParserConfig) {
+	once.Do(func() {
+		instance = &WorkflowParserFactory{
+			parsers: make(map[string]WorkflowParser),
+		}
+
+		for workflowType, config := range configs {
+			createFunc, exists := parserCreateFunc[workflowType]
+			if !exists {
+				panic("no parser registered for workflow type")
+			}
+			instance.parsers[workflowType] = createFunc(config)
+		}
+	})
+}
+
+func GetFactory() *WorkflowParserFactory {
+	return instance
+}
+
+func (f *WorkflowParserFactory) GetParser(workflowType string) (WorkflowParser, error) {
+	parser, exists := f.parsers[workflowType]
+	if !exists {
+		return nil, fmt.Errorf("no parser found for workflow type: %s", workflowType)
+	}
+	return parser, nil
+}

--- a/internal/context/workspace/infrastructure/workflowparser/workflowparser.go
+++ b/internal/context/workspace/infrastructure/workflowparser/workflowparser.go
@@ -31,11 +31,18 @@ func RegisterParseCreateFunc(workflowType string, function func(ParserConfig) Wo
 
 func init() {
 	RegisterParseCreateFunc(WDL, func(config ParserConfig) WorkflowParser {
-		wdlConfig, ok := config.(WDLConfig)
+		configParam, ok := config.(WDLConfig)
 		if !ok {
 			panic("Invalid config type for WDL parser")
 		}
-		return NewWDLParser(wdlConfig)
+		return NewWDLParser(configParam)
+	})
+	RegisterParseCreateFunc(CWL, func(config ParserConfig) WorkflowParser {
+		configParam, ok := config.(CWLConfig)
+		if !ok {
+			panic("Invalid config type for WDL parser")
+		}
+		return NewCWLParser(configParam)
 	})
 }
 

--- a/internal/context/workspace/interface/hertz/handlers/workflow_vo.go
+++ b/internal/context/workspace/interface/hertz/handlers/workflow_vo.go
@@ -15,7 +15,7 @@ type createWorkflowRequest struct {
 	WorkspaceID      string  `path:"workspace-id"`
 	Name             string  `json:"name" validate:"required,resName"`
 	Description      *string `json:"description" validate:"workspaceDesc"`
-	Language         string  `json:"language" validate:"required,oneof=WDL"`
+	Language         string  `json:"language" validate:"required,oneof=WDL CWL NFL SMK"`
 	Source           string  `json:"source" validate:"required,oneof=git"`
 	URL              string  `json:"url" validate:"required"`
 	Tag              string  `json:"tag" validate:"required"`
@@ -101,7 +101,7 @@ type updateWorkflowRequest struct {
 	ID               string  `path:"id"`
 	Name             *string `json:"name,omitempty"`
 	Description      *string `json:"description" validate:"workspaceDesc"`
-	Language         *string `json:"language,omitempty" validate:"required,oneof=WDL"`
+	Language         *string `json:"language,omitempty" validate:"required,oneof=WDL CWL NFL SMK"`
 	Source           *string `json:"source,omitempty" validate:"required,oneof=git"`
 	URL              *string `json:"url,omitempty"`
 	Tag              *string `json:"tag,omitempty"`

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -67,7 +67,7 @@ export interface GithubComBioOSBioosInternalContextWorkspaceInterfaceHertzHandle
 export interface HandlersCreateSubmissionRequest {
   description?: string;
   entity?: HandlersEntity;
-  exposedOptions?: HandlersExposedOptions;
+  exposedOptions?: string;
   inOutMaterial?: HandlersInOutMaterial;
   name?: string;
   type?: string;
@@ -113,10 +113,6 @@ export interface HandlersEntity {
    * 	  - 在 inputs/outputs 层级进行序列化可使得 `bioos-server` 不处理 `Inputs`/`Outputs`(非 `this.xxx` 索引的输入) 就入库/提交给计算引擎，达到透传效果
    */
   outputsTemplate?: string;
-}
-
-export interface HandlersExposedOptions {
-  readFromCache?: boolean;
 }
 
 export interface HandlersGetDataModelResponse {
@@ -233,7 +229,7 @@ export interface HandlersSubmissionItem {
   description?: string;
   duration?: number;
   entity?: HandlersEntity;
-  exposedOptions?: HandlersExposedOptions;
+  exposedOptions?: string;
   finishTime?: number;
   id?: string;
   inOutMaterial?: HandlersInOutMaterial;

--- a/web/src/components/workflow/ImportModal.tsx
+++ b/web/src/components/workflow/ImportModal.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { memo, useMemo, useRef } from 'react';
+import { memo, useMemo, useRef, useState } from 'react';
 import { Form as FinalForm } from 'react-final-form';
 import { useRouteMatch } from 'react-router-dom';
 import { FormApi } from 'final-form';
@@ -42,6 +42,10 @@ import { ToastLimitText } from '..';
 
 import style from './style.less';
 
+import WorkflowMode, {
+  WorkflowModeType,
+} from 'components/workflow/WorkflowMode';
+
 interface Props {
   visible: boolean;
   workflowInfo?: HandlersWorkflowItem;
@@ -54,12 +58,14 @@ function ImportModal({ visible, workflowInfo, onClose, refetch }: Props) {
   const match = useRouteMatch<{ workspaceId: string }>();
   const isEdit = workflowInfo?.latestVersion.status === 'Success';
   const isReimport = workflowInfo?.latestVersion.status === 'Failed';
+  const [language, setLanguage] = useState<WorkflowModeType>('WDL');
 
   const initialValues = useMemo(
     () =>
       workflowInfo
         ? {
             name: workflowInfo.name,
+            language: workflowInfo.latestVersion.language,
             url: workflowInfo.latestVersion.metadata.gitURL,
             tag: workflowInfo.latestVersion.metadata.gitTag,
             mainWorkflowPath: workflowInfo.latestVersion.mainWorkflowPath,
@@ -167,6 +173,13 @@ function ImportModal({ visible, workflowInfo, onClose, refetch }: Props) {
           return (
             <ArcoForm layout="vertical">
               <FieldItem
+                  name="language"
+                  label="工作流声明语言"
+                  required={true}
+              >
+                <WorkflowMode value={language} onChange={setLanguage} />
+              </FieldItem>
+              <FieldItem
                 name="name"
                 label="工作流名称"
                 required={true}
@@ -177,9 +190,6 @@ function ImportModal({ visible, workflowInfo, onClose, refetch }: Props) {
               >
                 <Input placeholder="请输入" allowClear={true} />
               </FieldItem>
-              <Form.Item label="规范">
-                <span>WDL</span>
-              </Form.Item>
               <FieldItem
                 name="url"
                 label="Git 地址"

--- a/web/src/components/workflow/WorkflowMode.tsx
+++ b/web/src/components/workflow/WorkflowMode.tsx
@@ -1,0 +1,80 @@
+import { memo} from 'react';
+import classNames from 'classnames';
+import { Radio } from '@arco-design/web-react';
+
+
+const RADIO_ARRAY = [
+  {
+    title: 'WDL',
+    value: 'WDL',
+  },
+  {
+    title: 'CWL',
+    value: 'CWL',
+  },
+  {
+    title: 'Nextflow',
+    description: '开发中',
+    value: 'NFL',
+    disabled: true,
+  },
+  {
+    title: 'Snakemake',
+    description: '开发中',
+    value: 'SMK',
+    disabled: true,
+  },
+];
+
+export type WorkflowModeType = (typeof RADIO_ARRAY)[number]['value'];
+
+function WorkflowMode({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string;
+  onChange: (val: string) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <Radio.Group value={value} className="flex" disabled={disabled}>
+      {RADIO_ARRAY.map(item => {
+        return (
+          <div
+            key={item.value}
+            className={classNames([
+              'fs12 br4 mr12',
+              { cursorPointer: !disabled && !item.disabled },
+            ])}
+            onClick={() => {
+              if (disabled || item.disabled) return;
+              onChange(item.value);
+            }}
+            style={{
+              padding: '12px 16px',
+              width: 114,
+              border:
+                item.value === value
+                  ? '1px solid #94c2ff'
+                  : '1px solid #e4e8ff',
+              background: item.value === value ? '#e8f4ff' : 'white',
+            }}
+          >
+            <div className="flexJustifyBetween">
+              <div className="flexAlignCenter">
+                <span className="colorBlack fw500 mr4">{item.title}</span>
+              </div>
+
+              <Radio value={item.value} style={{ marginRight: 0 }} />
+            </div>
+
+         
+          </div>
+        );
+      })}
+    </Radio.Group>
+  );
+}
+
+export default memo(WorkflowMode);

--- a/web/src/components/workflow/run/UploadJSON.tsx
+++ b/web/src/components/workflow/run/UploadJSON.tsx
@@ -81,10 +81,12 @@ export default function UploadJSON({
             let jsonVal = jsonObj[item.name];
 
             // String和File类型需要多加一层双引号
+            // Directory类型(CWL流程中会出现)也需要加引号
             if (
               jsonVal &&
               (item?.type.startsWith('String') ||
-                item?.type.startsWith('File')) &&
+              item?.type.startsWith('File') ||
+              item?.type.startsWith('Directory')) &&
               !(jsonVal?.startsWith('"') && jsonVal?.endsWith('"')) &&
               !isContextValue(jsonVal)
             ) {

--- a/web/src/pages/analysis/AnalysisDetail.tsx
+++ b/web/src/pages/analysis/AnalysisDetail.tsx
@@ -129,6 +129,18 @@ export default function AnalysisDetail() {
       (detailData?.status === 'Pending' ? 'Running' : detailData?.status),
   );
 
+  const parsedExposedOptions = useMemo(() => {
+    if (detailData?.exposedOptions) {
+      try {
+        return JSON.parse(detailData.exposedOptions);
+      } catch (e) {
+        console.error("Parsing exposedOptions failed", e);
+        return {};
+      }
+    }
+    return {};
+  }, [detailData]);
+
   //获取 icon 组件
   const getIcon = () => {
     switch (status?.icon) {
@@ -199,7 +211,7 @@ export default function AnalysisDetail() {
             id={detailData?.id}
             workspaceId={workspaceId}
             workflowId={detailData?.workflowVersion?.id}
-            flagReadFromCache={detailData?.exposedOptions?.readFromCache}
+            flagReadFromCache={parsedExposedOptions?.readFromCache}
           />
         </DetailRightContainer>
       </div>

--- a/web/src/pages/analysis/AnalysisTaskDetail.tsx
+++ b/web/src/pages/analysis/AnalysisTaskDetail.tsx
@@ -113,6 +113,18 @@ export default function AnalysisTaskDetail() {
 
   const status = RUN_STATUS_TAG.find(item => item.value === runData.status);
 
+  const parsedExposedOptions = useMemo(() => {
+    if (runSubmissionData?.exposedOptions) {
+      try {
+        return JSON.parse(runSubmissionData.exposedOptions);
+      } catch (e) {
+        console.error("Parsing exposedOptions failed", e);
+        return {};
+      }
+    }
+    return {};
+  }, [runSubmissionData]);
+
   useEffect(() => {
     startAnalysisDetailPolling();
     return () => stopAnalysisDetailPolling();
@@ -146,7 +158,7 @@ export default function AnalysisTaskDetail() {
           inputs={runData.inputs}
           outputs={runData.outputs}
           logs={logs}
-          callCache={runSubmissionData?.exposedOptions?.readFromCache}
+          callCache={parsedExposedOptions?.readFromCache}
           isFinished={isFinished}
         />
         <DetailRightContainer>

--- a/web/src/pages/workflow/Run.tsx
+++ b/web/src/pages/workflow/Run.tsx
@@ -308,10 +308,11 @@ export default function WorkflowRun() {
       workspaceID: workspaceId,
       workflowID: workflowId,
       type: isPath ? 'filePath' : 'dataModel',
-      exposedOptions: {
-        readFromCache: callCaching,
-      },
     };
+
+    body.exposedOptions = JSON.stringify({
+      readFromCache: callCaching,
+    })
 
     if (isPath) {
       body.inOutMaterial = {
@@ -515,7 +516,13 @@ export default function WorkflowRun() {
 
   useEffect(() => {
     if (!dataModelList) return;
-    setCallCaching(submission?.exposedOptions?.readFromCache ?? true);
+    try {
+      const exposedOptions = submission?.exposedOptions ? JSON.parse(submission.exposedOptions) : {};
+      setCallCaching(exposedOptions.readFromCache ?? true);
+    } catch (e) {
+      setCallCaching(true); // 解析失败时，使用默认值true
+    }
+
     if (!submissionId || submission?.type === 'filePath') {
       setModelId(dataModelList?.[0]?.id);
       setMode(submission?.type || 'dataModel');

--- a/web/src/pages/workflow/Run.tsx
+++ b/web/src/pages/workflow/Run.tsx
@@ -310,9 +310,7 @@ export default function WorkflowRun() {
       type: isPath ? 'filePath' : 'dataModel',
     };
 
-    body.exposedOptions = JSON.stringify({
-      readFromCache: callCaching,
-    });
+    body.exposedOptions = JSON.stringify(exposedOptions);
 
     if (isPath) {
       body.inOutMaterial = {
@@ -505,6 +503,59 @@ export default function WorkflowRun() {
     }
   }
 
+  function useLanguageOptions(language, submission) {
+    // 定义默认状态
+    const [optionStates, setOptionStates] = useState({
+      callCaching: true,
+      continueWhenFailed: true,
+      useConda: true,
+      // ...在此添加状态
+    });
+
+    // 根据状态对象生成 exposedOptions
+    const exposedOptions = useMemo(() => {
+      switch (language) {
+        case 'WDL':
+          const WDLOptions = {
+            readFromCache: optionStates.callCaching,
+          };
+          return WDLOptions;
+        case 'CWL':
+          const CWLOptions = {
+            workflowFailureMode: optionStates.continueWhenFailed ? 'ContinueWhilePossible' : 'NoNewCalls',
+          };
+          return CWLOptions;
+        case 'SMK':
+          const SMKOptions = {
+            useConda: optionStates.useConda,
+          };
+          return SMKOptions;
+        default:
+          return {};
+      }
+    }, [optionStates, language]);
+
+    // 通用的更新方法
+    const updateOptionState = (name, newValue) => {
+      setOptionStates(prevState => ({
+        ...prevState,
+        [name]: newValue,
+      }));
+    };
+
+    // 处理 submission 变化，更新状态对象
+    useEffect(() => {
+      if (submission) {
+        const submissionOptions = submission?.exposedOptions ? JSON.parse(submission.exposedOptions) : {};
+        Object.keys(submissionOptions).forEach(key => {
+          updateOptionState(key, submissionOptions[key]);
+        });
+      }
+    }, [submission]);
+
+    return { optionStates, updateOptionState, exposedOptions };
+  }
+
   // 获取初始数据
   useEffect(() => {
     getWorkflow();
@@ -514,14 +565,75 @@ export default function WorkflowRun() {
     }
   }, []);
 
+  const language = workflow?.latestVersion?.language;
+  const { optionStates, updateOptionState, exposedOptions } = useLanguageOptions(language, submission);
+
+  const getLanguageOptionsUI = (language, optionStates, updateOptionState) => {
+    switch (language) {
+      case 'WDL':
+        return (
+          <div className={style.row}>
+            <div className={style.col}>
+              CallCaching
+              <Popover content="CallCaching会在之前运行的任务的缓存中搜索具有完全相同的命令和完全相同的输入的任务。 如果缓存命中，将使用前一个任务的结果而不是重新运行，从而节省时间和资源。">
+                <IconQuestionCircle className="ml4" />
+              </Popover>
+            </div>
+            <div className={style.col}>
+              <Switch
+                checkedText="开"
+                uncheckedText="关"
+                checked={optionStates.callCaching}
+                onChange={checked => updateOptionState('callCaching', checked)}
+              />
+            </div>
+          </div>
+        );
+      case 'CWL':
+        return (
+          <div className={style.row}>
+            <div className={style.col}>
+              FailMode
+              <Popover content="单个任务失败后要立刻停止，还是尽可能地继续执行。开代表尽可能执行。">
+                <IconQuestionCircle className="ml4" />
+              </Popover>
+            </div>
+            <div className={style.col}>
+              <Switch
+                checkedText="开"
+                uncheckedText="关"
+                checked={optionStates.continueWhenFailed}
+                onChange={checked => updateOptionState('continueWhenFailed', checked)}
+              />
+            </div>
+          </div>
+        );
+      case 'SMK':
+        return (
+          <div className={style.row}>
+            <div className={style.col}>
+              UseConda
+              <Popover content="是否使用Conda">
+                <IconQuestionCircle className="ml4" />
+              </Popover>
+            </div>
+            <div className={style.col}>
+              <Switch
+                checkedText="开"
+                uncheckedText="关"
+                checked={optionStates.useConda}
+                onChange={checked => updateOptionState('useConda', checked)}
+              />
+            </div>
+          </div>
+        );
+      default:
+        return <div>No options available for this language.</div>;
+    }
+  };
+
   useEffect(() => {
     if (!dataModelList) return;
-    try {
-      const exposedOptions = submission?.exposedOptions ? JSON.parse(submission.exposedOptions) : {};
-      setCallCaching(exposedOptions.readFromCache ?? true);
-    } catch (e) {
-      setCallCaching(true); // 解析失败时，使用默认值true
-    }
 
     if (!submissionId || submission?.type === 'filePath') {
       setModelId(dataModelList?.[0]?.id);
@@ -725,23 +837,7 @@ export default function WorkflowRun() {
                     </div>
                   </>
                 )}
-
-                <div className={style.row}>
-                  <div className={style.col}>
-                    CallCaching
-                    <Popover content="CallCaching会在之前运行的任务的缓存中搜索具有完全相同的命令和完全相同的输入的任务。 如果缓存命中，将使用前一个任务的结果而不是重新运行，从而节省时间和资源。">
-                      <IconQuestionCircle className="ml4" />
-                    </Popover>
-                  </div>
-                  <div className={style.col}>
-                    <Switch
-                      checkedText="开"
-                      uncheckedText="关"
-                      checked={callCaching}
-                      onChange={setCallCaching}
-                    />
-                  </div>
-                </div>
+                {getLanguageOptionsUI(language, optionStates, updateOptionState)}
               </div>
             </div>
             <div className={style.blockBox}>

--- a/web/src/pages/workflow/Run.tsx
+++ b/web/src/pages/workflow/Run.tsx
@@ -312,7 +312,7 @@ export default function WorkflowRun() {
 
     body.exposedOptions = JSON.stringify({
       readFromCache: callCaching,
-    })
+    });
 
     if (isPath) {
       body.inOutMaterial = {
@@ -641,6 +641,18 @@ export default function WorkflowRun() {
                   }}
                 >
                   {workflow?.description}
+                </Typography.Paragraph>
+                <span className="">流程语言：</span>
+                <Typography.Paragraph
+                  className="colorGrey mr20"
+                  style={{ maxWidth: 100 }}
+                  ellipsis={{
+                    showTooltip: {
+                      type: 'popover',
+                    },
+                  }}
+                >
+                  {workflow?.latestVersion?.language}
                 </Typography.Paragraph>
                 <span>来源：</span>
                 <Link>{workflow?.latestVersion?.metadata?.gitURL}</Link>


### PR DESCRIPTION
# 流程语言拓展T4-Hiplot

## 功能说明

本项目在Kubernetes环境下完成了Sapporo的兼容，打破了Bio-OS开源发行版当前架构设计模式下单机应用的能力限制，使Bio-OS项目可以完整地部署在K8S集群环境中，并实现对K8S算力资源的有效调度。

本项目支持WDL、CWL、Nextflow、Snakemake四类生物医学领域主流的工作流声明语言（Bioos前端目前仅支持WDL CWL执行，另外两种正在开发中），并对Sapporo项目接口进行了标准化，使其可以暴露标准的WES接口，该接口可供Bio-OS项目 API server 无缝调用，可支持作为Bio-OS Nextflow WDL 等工作流运行的WES Endpoint。

简单总结：

1. 通过标准WES API接口调用
2. 支持WDL、CWL、Nextflow、Snakemake工作流语言
3. 基于Kubernetes进行部署和任务调度

### 详细设计

[![pi64wsP.png](https://z1.ax1x.com/2023/12/05/pi64wsP.png)](https://imgse.com/i/pi64wsP)

本项目设计了一个运行在Kubernetes上的全流程语言任务调度引擎，其主要包括两部分：一、基于Sapporo开发的支持WES API的API server；二、基于TESK的支持TES API的任务执行引擎。Sapporo收到提交任务请求后，对请求进行解析和处理，随后通过TES API向TESK服务器提交任务并执行。对不同的流程语言设计了不同的任务执行方式。

Bio-OS通过WES协议调用该引擎，主要用到的接口包括：POST /runs（提交任务）、GET /runs/{run_id}（查询任务日志）、POST /runs/{run_id}/cancel（取消任务）。

### 关键功能优化

1. Sapporo的标准WES API适配

2. Sapporo与BioOS APIserver对接

3. 在Kubernetes中部署TESK及Sapporo

4. 完成四种流程语言执行方式的修改

5. Bioos项目多语言适配及优化

   

## 使用演示

- 导入工作流

[![pi6U5VK.png](https://z1.ax1x.com/2023/12/05/pi6U5VK.png)](https://imgse.com/i/pi6U5VK)

- 查看工作流详细信息

[![pi6UIUO.png](https://z1.ax1x.com/2023/12/05/pi6UIUO.png)](https://imgse.com/i/pi6UIUO)
[![pi6Uo5D.png](https://z1.ax1x.com/2023/12/05/pi6Uo5D.png)](https://imgse.com/i/pi6Uo5D)
[![pi6Uhb6.png](https://z1.ax1x.com/2023/12/05/pi6Uhb6.png)](https://imgse.com/i/pi6Uhb6)
[![pi6U7Pe.png](https://z1.ax1x.com/2023/12/05/pi6U7Pe.png)](https://imgse.com/i/pi6U7Pe)

- 另一个工作流导入示例

[![pi6hgu6.png](https://z1.ax1x.com/2023/12/05/pi6hgu6.png)](https://imgse.com/i/pi6hgu6)
[![pi6hyg1.png](https://z1.ax1x.com/2023/12/05/pi6hyg1.png)](https://imgse.com/i/pi6hyg1)
[![pi64ePJ.png](https://z1.ax1x.com/2023/12/05/pi64ePJ.png)](https://imgse.com/i/pi64ePJ)
[![pi64mG9.png](https://z1.ax1x.com/2023/12/05/pi64mG9.png)](https://imgse.com/i/pi64mG9)

- 提交工作流任务

[![pi64V54.png](https://z1.ax1x.com/2023/12/05/pi64V54.png)](https://imgse.com/i/pi64V54)
[![pi64EaF.png](https://z1.ax1x.com/2023/12/05/pi64EaF.png)](https://imgse.com/i/pi64EaF)

- 运行结果

[![pi6h6jx.png](https://z1.ax1x.com/2023/12/05/pi6h6jx.png)](https://imgse.com/i/pi6h6jx)
[![pi6h0N4.png](https://z1.ax1x.com/2023/12/05/pi6h0N4.png)](https://imgse.com/i/pi6h0N4)
[![pi6h2DK.png](https://z1.ax1x.com/2023/12/05/pi6h2DK.png)](https://imgse.com/i/pi6h2DK)
[![pi6hB4J.png](https://z1.ax1x.com/2023/12/05/pi6hB4J.png)](https://imgse.com/i/pi6hB4J)
[![pi6hrC9.png](https://z1.ax1x.com/2023/12/05/pi6hrC9.png)](https://imgse.com/i/pi6hrC9)
[![pi6hs3R.png](https://z1.ax1x.com/2023/12/05/pi6hs3R.png)](https://imgse.com/i/pi6hs3R)



## Bio-os工作流扩展方法

扩展一种新的工作流语言，需要进行如下工作：

### Api-server端

internal\context\workspace\infrastructure\workflowparser

在这个包里，实现一个新的工作流语言解析器，包括以下内容：


[![pi65TnP.png](https://z1.ax1x.com/2023/12/05/pi65TnP.png)](https://imgse.com/i/pi65TnP)

internal\context\workspace\infrastructure\workflowparser\workflowparser.go

在这个文件里，初始化一个解析器注册函数

[![pi65IXt.png](https://z1.ax1x.com/2023/12/05/pi65IXt.png)](https://imgse.com/i/pi65IXt)

internal\context\workspace\application\command\workflow\commands.go

在这个文件里初始化解析器实例

[![pi6570f.png](https://z1.ax1x.com/2023/12/05/pi6570f.png)](https://imgse.com/i/pi6570f)

### Web端

web\src\pages\workflow\Run.tsx

在下图所示函数中定义各种工作流语言所对应的exposedOptions

[![pi6I89H.png](https://z1.ax1x.com/2023/12/05/pi6I89H.png)](https://imgse.com/i/pi6I89H)

在下图所示部分设计对应的ui界面

[![pi6I14e.png](https://z1.ax1x.com/2023/12/05/pi6I14e.png)](https://imgse.com/i/pi6I14e)


## 新增功能

- 新增了基于sapporo和tesk的工作流执行引擎，兼容标准wes api，对Bio-os的调用进行了适配工作
- 导入工作流时支持不同工作流语言选择
- 将工作流语言解析部分抽象出一个单独的模块
- 实现了CWL工作流解析
- 修复提交工作流时attachment共有路径和文件名截取错误的问题(之前所有文件名会被误截掉两个字符)
- 提交工作流的wes api中增加workflow_url参数，用于在多个文件中指定工作流入口
- 在web中增加可对每种工作流单独定义的exposedOptions，并改用string类型传输
- 修复一处变量使用错误
[![pi6IlND.png](https://z1.ax1x.com/2023/12/05/pi6IlND.png)](https://imgse.com/i/pi6IlND)
- 前端导入json时，增加对Directory类型输入自动添加”的处理
- 使用wes api获取运行日志时，使用stdout补全api中没有的log字段




## 后端服务

### 代码地址

1. sapporo

   [Githhub仓库地址](https://github.com/Bioos-hiplot/sapporo-hiplot)

   支持docker部署和k8s部署，分别在develop和develop-k8s分支

2. TESK

   [Github仓库地址](https://github.com/Bioos-hiplot/tesk-hiplot)

### 使用指南

1. 部署Bio-os项目

2. 为WES Endpoint配置代理

   通过Sapporo作为统一的WES后端，不同的工作流声明语言的仅暴露同一个WES endpoint，由于Sapporo WES Base URL 与Cromwell WES Base URL存在差异，为了尽可能少的干预两个项目的原初设计，使用Nginx对Sapporo所暴露的服务进行转发，如下：

   ```txt
   server {
               listen [bioos-wes-port];
               server_name 127.0.0.1;
   
               location /api/ga4gh/wes/v1/{
                   proxy_pass http://127.0.0.1:[sapporo=port]/;
                   proxy_set_header Host $host;
                   proxy_set_header X-Real-IP $remote_addr;
                }
           }
   ```

  亦可在Bio-OS 项目 Config中修改 WES bath path 参数，但会影响api-server与Cromwell的wes endpoint的对接。

3. 部署Sapporo

   以下是k8s部署步骤，若使用docker部署，可参考develop分支下的docker-compose.dev.yaml文件
   
   按需修改deployment.yaml和service.yaml中存储、端口、namespace等相关配置，随后依次执行如下命令部署：

   ```shell
   # 构建镜像
   docker build -t sapporo-service-dev -f Dockerfile-dev . 
   #  我们使用minikube的测试环境，此处导入了镜像，也可上传到公共仓库
   minikube image load sapporo-service-dev 
   
   kubectl apply -f deployment.yaml  # 创建deployment
   kubectl apply -f service.yaml  #  创建service
   
   # 若采用默认配置，则可使用下面命令检查部署
   kubectl -n bioos port-forward --address 0.0.0.0 service/sapporo-service 1188:1122  # 转发端口到宿主机
   curl -fsSL -X GET http://127.0.0.1:1188/service-info   # 获取service-info
   ```

4. TESK部署

   按需修改charts\tesk\values.yaml中存储、端口相关参数：

   ```txt
   service:
   type: "NodePort"
   node_port: "31567"
   ```

   在charts\tesk\templates\common\tesk-deployment.yaml中修改数据卷挂载的相关参数：

   [![pi64jL6.png](https://z1.ax1x.com/2023/12/05/pi64jL6.png)](https://imgse.com/i/pi64jL6)

   随后依次执行如下命令部署：

   ```shell
   cd customize/tesk-core
   docker build -t tesk-core-filer-hiplot:v0.10.1 .  #  构建新的taskmaster_filer_image_name镜像
   minikube image load tesk-core-filer-hiplot:v0.10.1  #  我们使用minikube的测试环境，此处导入了镜像，也可上传到公共仓库
   
   cd ../../charts/tesk
   helm upgrade -n bioos --install tesk-release . -f secrets.yaml -f values.yaml # 安装tesk
   # 如果修改了service名称和端口，需要对应修改sapporo项目中的const.py中对应内容
   
   # 部署完成后，若采用默认参数，则可使用下面命令检查部署
   curl -fsSL -X GET http://[所在节点的ip]:31567/ga4gh/tes/v1/service-info
   ```

### 测试

Bio-os中，导入测试使用cwl流程：[NCI-GDC/gdc-rnaseq-cwl](https://github.com/NCI-GDC/gdc-rnaseq-cwl) 及 [hacchy1983/CWL-workflows](https://github.com/hacchy1983/CWL-workflows/tree/master)

执行测试使用cwl流程：[hacchy1983/CWL-workflows](https://github.com/hacchy1983/CWL-workflows/tree/master)


snakemake及nextflow语言，在bioos端完成适配后方可使用。目前可通过手动提交请求测试，所有用到的测试流程和文件都在sapporo的develop-k8s分支中的sapporo/test-examples文件夹给出。测试方法如下，其中所使用的地址和端口需对应替换：

```shell
# SMK测试
curl -fsSL -X POST -H "Content-Type: multipart/form-data" \
-F "workflow_type=SMK" -F "workflow_type_version=1.0" \
-F "workflow_params=<./test-examples/SNAKEMAKE/workflow_params.json" \
-F "workflow_attachment=@./test-examples/SNAKEMAKE/Snakefile;filename=Snakefile" \
http://127.0.0.1:1188/runs


# NFL测试
curl -fsSL -X POST -H "Content-Type: multipart/form-data" \
-F "workflow_type=NFL" -F "workflow_type_version=1.0" \
-F "workflow_params=<./test-examples/NEXTFLOW/workflow_params.json" \
-F "workflow_attachment=@./test-examples/NEXTFLOW/file_input.nf" \
http://127.0.0.1:1188/runs
